### PR TITLE
added getDatabasePort method

### DIFF
--- a/src/Facts.php
+++ b/src/Facts.php
@@ -235,6 +235,14 @@ class Facts
     /**
      * @return mixed
      */
+    public function getDatabasePort()
+    {
+        return $this->getConfigReader()->dbPort;
+    }
+
+    /**
+     * @return mixed
+     */
     public function getDatabaseDriver()
     {
         return $this->getConfigReader()->dbType;


### PR DESCRIPTION
This is needed to run migrations with a non standard mysql port.
This is the case with a lot of hosters, in my case Profihost.
I consider this a blocker for using OXID.

An according PR will be made on oxideshop-doctrine-migration-wrapper.