### PR TITLE
[oxidio] fix packagist deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Deprecation warning: require-dev.mikey179/vfsStream is invalid,
it should not contain uppercase characters.
Please use mikey179/vfsstream instead.
Make sure you fix this as Composer 2.0 will error.