### PR TITLE
prefer INSTALLATION_ROOT_PATH to __DIR__ constants

### DIFF
--- a/src/Config/ConfigFile.php
+++ b/src/Config/ConfigFile.php
@@ -52,7 +52,11 @@ class ConfigFile
         $autoloaderName = 'vendor/autoload.php';
         $count = 0;
         while ($count < 8) {
-            $fullPathToAutoload = __DIR__ . $pathToAutoloadFromThisScript;
+            if (defined('INSTALLATION_ROOT_PATH')) {
+                $fullPathToAutoload = INSTALLATION_ROOT_PATH . $pathToAutoloadFromThisScript;
+            } else {
+                $fullPathToAutoload = __DIR__ . $pathToAutoloadFromThisScript;
+            }
             if (is_file($fullPathToAutoload . $autoloaderName)) {
                 $rootPath = $fullPathToAutoload;
                 $pathToConfigIncFile = $rootPath.'source/config.inc.php';

--- a/src/Facts.php
+++ b/src/Facts.php
@@ -90,7 +90,7 @@ class Facts
             '/../../../../vendor',
         ];
 
-        $rootPath = '';
+        $rootPath = getcwd();
         foreach ($vendorPaths as $vendorPath) {
             if (file_exists(Path::join($this->startPath, $vendorPath))) {
                 $rootPath = Path::join($this->startPath, $vendorPath, '..');

--- a/src/Facts.php
+++ b/src/Facts.php
@@ -58,13 +58,21 @@ class Facts
     protected $configReader = null;
 
     /**
+     * @var string
+     */
+    protected $startPath;
+
+    /**
      * Facts constructor.
      *
      * @param string $startPath               Start path.
      * @param null   $configFile              Optional ConfigFile
      */
-    public function __construct($startPath = __DIR__, $configFile = null)
+    public function __construct($startPath = null, $configFile = null)
     {
+        if (!$startPath) {
+            $startPath = defined('INSTALLATION_ROOT_PATH') ? INSTALLATION_ROOT_PATH : __DIR__;
+        }
         $this->startPath = $startPath;
         $this->configReader = $configFile;
     }


### PR DESCRIPTION
prefer `INSTALLATION_ROOT_PATH` to `__DIR__` constants, 
for the case this package is installed as (absolut) path repo:

## /app/composer.json
```json
...
  "repositories": [
    {"type":  "path", "url": "/a-docker-mount/*"}
  ],
  "require": {
    "oxid-esales/oxideshop-facts": "^2.0",
  },
...
```